### PR TITLE
Removed deprecated throw, replaced with revert

### DIFF
--- a/src/CATFreezer.sol
+++ b/src/CATFreezer.sol
@@ -25,23 +25,23 @@ contract CATFreezer {
 
 		firstThawDate = now + 365 days;  // One year from now
 		secondThawDate = now + 2 * 365 days;  // Two years from now
-		
+
 		firstUnlocked = false;
 	}
 
 	function unlockFirst() external {
-		if (firstUnlocked) throw;
-		if (msg.sender != postFreezeDevCATDestination) throw;
-		if (now < firstThawDate) throw;
-		
+		if (firstUnlocked) revert();
+		if (msg.sender != postFreezeDevCATDestination) revert();
+		if (now < firstThawDate) revert();
+
 		firstUnlocked = true;
-		
+
 		uint256 totalBalance = StandardToken(CATContract).balanceOf(this);
 
 		// Allocations are each 50% of developer tokens
 		firstAllocation = totalBalance.div(2);
 		secondAllocation = totalBalance.sub(firstAllocation);
-		
+
 		uint256 tokens = firstAllocation;
 		firstAllocation = 0;
 
@@ -49,10 +49,10 @@ contract CATFreezer {
 	}
 
 	function unlockSecond() external {
-		if (!firstUnlocked) throw;
-		if (msg.sender != postFreezeDevCATDestination) throw;
-		if (now < secondThawDate) throw;
-		
+		if (!firstUnlocked) revert();
+		if (msg.sender != postFreezeDevCATDestination) revert();
+		if (now < secondThawDate) revert();
+
 		uint256 tokens = secondAllocation;
 		secondAllocation = 0;
 
@@ -60,7 +60,7 @@ contract CATFreezer {
 	}
 
 	function changeCATDestinationAddress(address _newAddress) external {
-		if (msg.sender != postFreezeDevCATDestination) throw;
+		if (msg.sender != postFreezeDevCATDestination) revert();
 		postFreezeDevCATDestination = _newAddress;
 	}
 }

--- a/src/CATToken.sol
+++ b/src/CATToken.sol
@@ -4,26 +4,26 @@ import "zeppelin-solidity/contracts/SafeMath.sol";
 
 contract CATToken is StandardToken {
 	using SafeMath for uint256;
-	
+
 	// keccak256 hash of hidden cap
 	string public constant HIDDEN_CAP = "0xd22f19d54193ff5e08e7ba88c8e52ec1b9fc8d4e0cf177e1be8a764fa5b375fa";
-	
+
 	// Events
 	event CreatedCAT(address indexed _creator, uint256 _amountOfCAT);
 	event CATRefundedForWei(address indexed _refunder, uint256 _amountOfWei);
-	
+
 	// Token data
 	string public constant name = "BlockCAT Token";
 	string public constant symbol = "CAT";
 	uint256 public constant decimals = 18;  // Since our decimals equals the number of wei per ether, we needn't multiply sent values when converting between CAT and ETH.
 	string public version = "1.0";
-	
+
 	// Addresses and contracts
 	address public executor;
 	address public devETHDestination;
 	address public devCATDestination;
 	address public reserveCATDestination;
-	
+
 	// Sale data
 	bool public saleHasEnded;
 	bool public minCapReached;
@@ -41,7 +41,7 @@ contract CATToken is StandardToken {
 	uint256 public constant CAT_PER_ETH_BASE_RATE = 300;  // 300 CAT = 1 ETH during normal part of token sale
 	uint256 public constant CAT_PER_ETH_FIRST_EARLY_BIRD_RATE = 330;
 	uint256 public constant CAT_PER_ETH_SECOND_EARLY_BIRD_RATE = 315;
-	
+
 	function CATToken(
 		address _devETHDestination,
 		address _devCATDestination,
@@ -50,13 +50,13 @@ contract CATToken is StandardToken {
 		uint256 _saleEndBlock
 	) {
 		// Reject on invalid ETH destination address or CAT destination address
-		if (_devETHDestination == address(0x0)) throw;
-		if (_devCATDestination == address(0x0)) throw;
-		if (_reserveCATDestination == address(0x0)) throw;
+		if (_devETHDestination == address(0x0)) revert();
+		if (_devCATDestination == address(0x0)) revert();
+		if (_reserveCATDestination == address(0x0)) revert();
 		// Reject if sale ends before the current block
-		if (_saleEndBlock <= block.number) throw;
+		if (_saleEndBlock <= block.number) revert();
 		// Reject if the sale end time is less than the sale start time
-		if (_saleEndBlock <= _saleStartBlock) throw;
+		if (_saleEndBlock <= _saleStartBlock) revert();
 
 		executor = msg.sender;
 		saleHasEnded = false;
@@ -73,18 +73,18 @@ contract CATToken is StandardToken {
 
 		totalSupply = 0;
 	}
-	
+
 	function createTokens() payable external {
 		// If sale is not active, do not create CAT
-		if (saleHasEnded) throw;
-		if (block.number < saleStartBlock) throw;
-		if (block.number > saleEndBlock) throw;
+		if (saleHasEnded) revert();
+		if (block.number < saleStartBlock) revert();
+		if (block.number > saleEndBlock) revert();
 		// Check if the balance is greater than the security cap
 		uint256 newEtherBalance = totalETHRaised.add(msg.value);
-		if (newEtherBalance > SECURITY_ETHER_CAP) throw; 
+		if (newEtherBalance > SECURITY_ETHER_CAP) revert();
 		// Do not do anything if the amount of ether sent is 0
-		if (0 == msg.value) throw;
-		
+		if (0 == msg.value) revert();
+
 		// Calculate the CAT to ETH rate for the current time period of the sale
 		uint256 curTokenRate = CAT_PER_ETH_BASE_RATE;
 		if (block.number < saleFirstEarlyBirdEndBlock) {
@@ -93,10 +93,10 @@ contract CATToken is StandardToken {
 		else if (block.number < saleSecondEarlyBirdEndBlock) {
 			curTokenRate = CAT_PER_ETH_SECOND_EARLY_BIRD_RATE;
 		}
-		
+
 		// Calculate the amount of CAT being purchased
 		uint256 amountOfCAT = msg.value.mul(curTokenRate);
-		
+
 		// Ensure that the transaction is safe
 		uint256 totalSupplySafe = totalSupply.add(amountOfCAT);
 		uint256 balanceSafe = balances[msg.sender].add(amountOfCAT);
@@ -111,15 +111,15 @@ contract CATToken is StandardToken {
 
 		CreatedCAT(msg.sender, amountOfCAT);
 	}
-	
+
 	function endSale() {
 		// Do not end an already ended sale
-		if (saleHasEnded) throw;
+		if (saleHasEnded) revert();
 		// Can't end a sale that hasn't hit its minimum cap
-		if (!minCapReached) throw;
+		if (!minCapReached) revert();
 		// Only allow the owner to end the sale
-		if (msg.sender != executor) throw;
-		
+		if (msg.sender != executor) revert();
+
 		saleHasEnded = true;
 
 		// Calculate and create developer and reserve portion of CAT
@@ -132,27 +132,27 @@ contract CATToken is StandardToken {
 		totalSupply = totalSupplySafe;
 		balances[devCATDestination] = devShare;
 		balances[reserveCATDestination] = reserveShare;
-		
+
 		CreatedCAT(devCATDestination, devShare);
 		CreatedCAT(reserveCATDestination, reserveShare);
 
 		if (this.balance > 0) {
-			if (!devETHDestination.call.value(this.balance)()) throw;
+			if (!devETHDestination.call.value(this.balance)()) revert();
 		}
 	}
 
 	// Allows BlockCAT to withdraw funds
 	function withdrawFunds() {
 		// Disallow withdraw if the minimum hasn't been reached
-		if (!minCapReached) throw;
-		if (0 == this.balance) throw;
+		if (!minCapReached) revert();
+		if (0 == this.balance) revert();
 
-		if (!devETHDestination.call.value(this.balance)()) throw;
+		if (!devETHDestination.call.value(this.balance)()) revert();
 	}
-	
+
 	// Signals that the sale has reached its minimum funding goal
 	function triggerMinCap() {
-		if (msg.sender != executor) throw;
+		if (msg.sender != executor) revert();
 
 		minCapReached = true;
 	}
@@ -160,56 +160,56 @@ contract CATToken is StandardToken {
 	// Opens refunding.
 	function triggerRefund() {
 		// No refunds if the sale was successful
-		if (saleHasEnded) throw;
+		if (saleHasEnded) revert();
 		// No refunds if minimum cap is hit
-		if (minCapReached) throw;
+		if (minCapReached) revert();
 		// No refunds if the sale is still progressing
-		if (block.number < saleEndBlock) throw;
-		if (msg.sender != executor) throw;
+		if (block.number < saleEndBlock) revert();
+		if (msg.sender != executor) revert();
 
 		allowRefund = true;
 	}
 
 	function refund() external {
 		// No refunds until it is approved
-		if (!allowRefund) throw;
+		if (!allowRefund) revert();
 		// Nothing to refund
-		if (0 == ETHContributed[msg.sender]) throw;
+		if (0 == ETHContributed[msg.sender]) revert();
 
 		// Do the refund.
 		uint256 etherAmount = ETHContributed[msg.sender];
 		ETHContributed[msg.sender] = 0;
 
 		CATRefundedForWei(msg.sender, etherAmount);
-		if (!msg.sender.send(etherAmount)) throw;
+		if (!msg.sender.send(etherAmount)) revert();
 	}
 
 	function changeDeveloperETHDestinationAddress(address _newAddress) {
-		if (msg.sender != executor) throw;
+		if (msg.sender != executor) revert();
 		devETHDestination = _newAddress;
 	}
-	
+
 	function changeDeveloperCATDestinationAddress(address _newAddress) {
-		if (msg.sender != executor) throw;
+		if (msg.sender != executor) revert();
 		devCATDestination = _newAddress;
 	}
-	
+
 	function changeReserveCATDestinationAddress(address _newAddress) {
-		if (msg.sender != executor) throw;
+		if (msg.sender != executor) revert();
 		reserveCATDestination = _newAddress;
 	}
-	
+
 	function transfer(address _to, uint _value) {
 		// Cannot transfer unless the minimum cap is hit
-		if (!minCapReached) throw;
-		
+		if (!minCapReached) revert();
+
 		super.transfer(_to, _value);
 	}
-	
+
 	function transferFrom(address _from, address _to, uint _value) {
 		// Cannot transfer unless the minimum cap is hit
-		if (!minCapReached) throw;
-		
+		if (!minCapReached) revert();
+
 		super.transferFrom(_from, _to, _value);
 	}
 }


### PR DESCRIPTION
Throw is deprecated in Solidity. I replaced it with revert() everywhere although we could essentially decide if require/assert makes more sense but that would have implications on the gas used.